### PR TITLE
Fixed request format for hero query

### DIFF
--- a/overwatch_api/overwatch_api.py
+++ b/overwatch_api/overwatch_api.py
@@ -68,7 +68,7 @@ class OverwatchAPI:
     def get_stats_one_hero(self,platform,region,battle_tag,hero):
         return self._base_request(
             platform,region,battle_tag,
-            'hero/' + hero
+            'hero/' + hero + '/'
         )
 
     def get_stats(self,platform,region,battle_tag):


### PR DESCRIPTION
Formatting for hero request requires a trailing forward slash else a 404 is thrown
